### PR TITLE
[HUST CSE] [lwext4] fix: dfs_ext_unmount function return value

### DIFF
--- a/ports/rtthread/dfs_ext.c
+++ b/ports/rtthread/dfs_ext.c
@@ -129,7 +129,7 @@ static int dfs_ext_unmount(struct dfs_filesystem *fs)
     }
     else
     {
-        rc = -RT_ERROR;
+        rc = -RT_EINVAL;
     }
     return rc;
 }

--- a/ports/rtthread/dfs_ext.c
+++ b/ports/rtthread/dfs_ext.c
@@ -122,8 +122,15 @@ static int dfs_ext_unmount(struct dfs_filesystem *fs)
         {
             dfs_ext4_blockdev_destroy(dbd);
         }
+        else
+        {
+            rc = -rc;
+        }
     }
-
+    else
+    {
+        rc = -RT_ERROR;
+    }
     return rc;
 }
 


### PR DESCRIPTION
fix: dfs_ext_unmount function return value
完善了dfs_ext_unmount函数的返回值